### PR TITLE
Handover exception to ray

### DIFF
--- a/index.php
+++ b/index.php
@@ -51,6 +51,11 @@ Kirby::plugin('genxbe/ray', [
             return X\Ray::ray($this, $color);
 		},
 	],
+    'hooks' => [
+        'system.exception' => function ($exception) {
+            ray()->exception($exception);
+        },
+    ],
 ]);
 
 if (function_exists('ray') && (!option('debug') && !option('genxbe.ray.enabled'))) {


### PR DESCRIPTION
Kirby 3.6.1 introduced the new `system.exception` [hook](https://github.com/getkirby/kirby/pull/3952). With this PR, Kirby exceptions will automatically be handed over to Ray.